### PR TITLE
benchmark for listcomprehention and original append

### DIFF
--- a/notebooks/gpt_model_prep.ipynb
+++ b/notebooks/gpt_model_prep.ipynb
@@ -376,17 +376,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "467 ns ± 69.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit \n",
+    "\n",
+    "code_commentary_lines = [\"code_commentary_lines\", \"code_commentary_lines\", \"code_commentary_lines\"]\n",
+    "commentary_lines = [\"commentary_lines\", \"commentary_lines\", \"commentary_lines\"]\n",
+    "\n",
+    "[code_commentary_lines.append(e) for e in commentary_lines]"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "242 ns ± 41.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit \n",
+    "\n",
+    "code_commentary_lines = [\"code_commentary_lines\", \"code_commentary_lines\", \"code_commentary_lines\"]\n",
+    "commentary_lines = [\"commentary_lines\", \"commentary_lines\", \"commentary_lines\"]\n",
+    "\n",
+    "for a_line in commentary_lines:\n",
+    "        code_commentary_lines.append(a_line)\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -412,7 +443,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
You can use list comprehention like :

[code_commentary_lines.append(e) for e in commentary_lines]

or 

code_commentary_lines += [ e for e in commentary_lines]

but original append is faster:
for a_line in commentary_lines:
        code_commentary_lines.append(a_line)